### PR TITLE
Add FastAPI front-end skeleton

### DIFF
--- a/src/financial_investing_platform/main.py
+++ b/src/financial_investing_platform/main.py
@@ -1,0 +1,162 @@
+from fastapi import FastAPI, Request, Form, WebSocket, WebSocketDisconnect
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from starlette.middleware.sessions import SessionMiddleware
+import uvicorn
+
+app = FastAPI()
+app.add_middleware(SessionMiddleware, secret_key="CHANGE_ME")
+templates = Jinja2Templates(directory=str(__package__).replace('.', '/') + "/templates")
+
+# In-memory data stores
+users = {"admin": "password"}
+stocks = []
+options = []
+risk_profiles = []
+
+
+def get_user(request: Request):
+    return request.session.get("user")
+
+
+@app.get("/login")
+def login_form(request: Request):
+    return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.post("/login")
+def login(request: Request, username: str = Form(...), password: str = Form(...)):
+    if users.get(username) == password:
+        request.session["user"] = username
+        return RedirectResponse("/stocks", status_code=303)
+    return templates.TemplateResponse("login.html", {"request": request, "error": "Invalid credentials"})
+
+
+@app.get("/logout")
+def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse("/login", status_code=303)
+
+
+@app.get("/stocks")
+def get_stocks(request: Request):
+    if not get_user(request):
+        return RedirectResponse("/login", status_code=303)
+    return templates.TemplateResponse("stocks.html", {"request": request, "stocks": stocks})
+
+
+@app.get("/stocks/new")
+def new_stock(request: Request):
+    return templates.TemplateResponse("stock_form.html", {"request": request, "form_title": "Add Stock", "action": "/stocks", "stock": None})
+
+
+@app.get("/stocks/{ticker}/edit")
+def edit_stock(request: Request, ticker: str):
+    stock = next((s for s in stocks if s["ticker"] == ticker), None)
+    return templates.TemplateResponse("stock_form.html", {"request": request, "form_title": "Edit Stock", "action": f"/stocks/{ticker}", "stock": stock})
+
+
+@app.post("/stocks")
+def create_stock(ticker: str = Form(...), shares: int = Form(...), avg_price_paid: float = Form(...), cost_basis: float = Form(...), current_price: float = Form(...)):
+    stocks.append({"ticker": ticker, "shares": shares, "avg_price_paid": avg_price_paid, "cost_basis": cost_basis, "current_price": current_price, "last_updated": "-", "is_active": True})
+    return RedirectResponse("/stocks", status_code=303)
+
+
+@app.post("/stocks/{ticker}")
+def update_stock(request: Request, ticker: str, shares: int = Form(None), avg_price_paid: float = Form(None), cost_basis: float = Form(None), current_price: float = Form(None), delete: int = Form(0)):
+    stock = next((s for s in stocks if s["ticker"] == ticker), None)
+    if not stock:
+        return RedirectResponse("/stocks", status_code=303)
+    if delete:
+        stock["is_active"] = False
+    else:
+        stock.update({"shares": shares, "avg_price_paid": avg_price_paid, "cost_basis": cost_basis, "current_price": current_price})
+    return RedirectResponse("/stocks", status_code=303)
+
+
+@app.get("/options")
+def get_options(request: Request):
+    if not get_user(request):
+        return RedirectResponse("/login", status_code=303)
+    return templates.TemplateResponse("options.html", {"request": request, "options": options})
+
+
+@app.get("/options/new")
+def new_option(request: Request):
+    return templates.TemplateResponse("option_form.html", {"request": request, "form_title": "Add Option", "action": "/options", "option": None})
+
+
+@app.get("/options/{opt_tkr}/edit")
+def edit_option(request: Request, opt_tkr: str):
+    opt = next((o for o in options if o["option_ticker"] == opt_tkr), None)
+    return templates.TemplateResponse("option_form.html", {"request": request, "form_title": "Edit Option", "action": f"/options/{opt_tkr}", "option": opt})
+
+
+@app.post("/options")
+def create_option(option_ticker: str = Form(...), ticker: str = Form(...), quantity: int = Form(...), expiration_date: str = Form(...), avg_price: float = Form(...), cost_basis: float = Form(...)):
+    options.append({"option_ticker": option_ticker, "ticker": ticker, "quantity": quantity, "expiration_date": expiration_date, "avg_price": avg_price, "cost_basis": cost_basis, "last_updated": "-", "is_active": True})
+    return RedirectResponse("/options", status_code=303)
+
+
+@app.post("/options/{opt_tkr}")
+def update_option(opt_tkr: str, ticker: str = Form(None), quantity: int = Form(None), expiration_date: str = Form(None), avg_price: float = Form(None), cost_basis: float = Form(None), delete: int = Form(0)):
+    opt = next((o for o in options if o["option_ticker"] == opt_tkr), None)
+    if not opt:
+        return RedirectResponse("/options", status_code=303)
+    if delete:
+        opt["is_active"] = False
+    else:
+        opt.update({"ticker": ticker, "quantity": quantity, "expiration_date": expiration_date, "avg_price": avg_price, "cost_basis": cost_basis})
+    return RedirectResponse("/options", status_code=303)
+
+
+@app.get("/risk")
+def get_risk(request: Request):
+    if not get_user(request):
+        return RedirectResponse("/login", status_code=303)
+    return templates.TemplateResponse("risk.html", {"request": request, "risk_profiles": risk_profiles})
+
+
+@app.get("/risk/new")
+def new_risk(request: Request):
+    return templates.TemplateResponse("risk_form.html", {"request": request, "form_title": "Add Risk", "action": "/risk", "risk": None})
+
+
+@app.get("/risk/{ticker}/edit")
+def edit_risk(request: Request, ticker: str):
+    rp = next((r for r in risk_profiles if r["ticker"] == ticker), None)
+    return templates.TemplateResponse("risk_form.html", {"request": request, "form_title": "Edit Risk", "action": f"/risk/{ticker}", "risk": rp})
+
+
+@app.post("/risk")
+def create_risk(ticker: str = Form(...), min_prob_OTM: float = Form(...), max_prob_OTM: float = Form(...), min_rorc: float = Form(...)):
+    risk_profiles.append({"ticker": ticker, "min_prob_OTM": min_prob_OTM, "max_prob_OTM": max_prob_OTM, "min_rorc": min_rorc, "last_updated": "-", "is_active": True})
+    return RedirectResponse("/risk", status_code=303)
+
+
+@app.post("/risk/{ticker}")
+def update_risk(ticker: str, min_prob_OTM: float = Form(None), max_prob_OTM: float = Form(None), min_rorc: float = Form(None), delete: int = Form(0)):
+    rp = next((r for r in risk_profiles if r["ticker"] == ticker), None)
+    if not rp:
+        return RedirectResponse("/risk", status_code=303)
+    if delete:
+        rp["is_active"] = False
+    else:
+        rp.update({"min_prob_OTM": min_prob_OTM, "max_prob_OTM": max_prob_OTM, "min_rorc": min_rorc})
+    return RedirectResponse("/risk", status_code=303)
+
+
+@app.websocket("/ws/options")
+async def options_ws(ws: WebSocket):
+    await ws.accept()
+    try:
+        while True:
+            await ws.send_json({"msg": "price", "count": len(options)})
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        pass
+
+
+if __name__ == "__main__":
+    uvicorn.run("financial_investing_platform.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/src/financial_investing_platform/templates/base.html
+++ b/src/financial_investing_platform/templates/base.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title | default('Financial Platform') }}</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        table { border-collapse: collapse; width: 100%; margin-bottom: 1em; }
+        th, td { border: 1px solid #ccc; padding: 0.4em; text-align: left; }
+        nav a { margin-right: 1em; }
+    </style>
+    {% block head_extra %}{% endblock %}
+</head>
+<body>
+<nav>
+    <a href="/stocks">Stocks</a>
+    <a href="/options">Options</a>
+    <a href="/risk">Risk</a>
+    <a href="/logout">Logout</a>
+</nav>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/src/financial_investing_platform/templates/login.html
+++ b/src/financial_investing_platform/templates/login.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Login</h1>
+<form method="post" action="/login">
+  <label for="username">Username:</label>
+  <input type="text" name="username" id="username" required>
+  <label for="password">Password:</label>
+  <input type="password" name="password" id="password" required>
+  <button type="submit">Login</button>
+</form>
+{% endblock %}

--- a/src/financial_investing_platform/templates/option_form.html
+++ b/src/financial_investing_platform/templates/option_form.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ form_title }}</h1>
+<form method="post" action="{{ action }}">
+  <label>Option Ticker: <input type="text" name="option_ticker" value="{{ option.option_ticker|default('') }}" {% if option %}readonly{% endif %}></label><br>
+  <label>Ticker: <input type="text" name="ticker" value="{{ option.ticker|default('') }}"></label><br>
+  <label>Quantity: <input type="number" name="quantity" value="{{ option.quantity|default('') }}"></label><br>
+  <label>Expiration Date: <input type="date" name="expiration_date" value="{{ option.expiration_date|default('') }}"></label><br>
+  <label>Avg Price: <input type="number" step="0.01" name="avg_price" value="{{ option.avg_price|default('') }}"></label><br>
+  <label>Cost Basis: <input type="number" step="0.01" name="cost_basis" value="{{ option.cost_basis|default('') }}"></label><br>
+  <button type="submit">Submit</button>
+</form>
+{% endblock %}

--- a/src/financial_investing_platform/templates/options.html
+++ b/src/financial_investing_platform/templates/options.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block head_extra %}
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const ws = new WebSocket(`ws://${location.host}/ws/options`);
+    ws.onmessage = (ev) => console.log('Price tick:', ev.data);
+  });
+</script>
+{% endblock %}
+{% block content %}
+<h1>Options</h1>
+<a href="/options/new">Add Option</a>
+<table>
+  <tr>
+    <th>Ticker</th><th>Option Ticker</th><th>Qty</th><th>Exp Date</th><th>Avg Price</th><th>Cost Basis</th><th>Actions</th>
+  </tr>
+  {% for o in options %}
+  <tr>
+    <td>{{ o.ticker }}</td><td>{{ o.option_ticker }}</td><td>{{ o.quantity }}</td><td>{{ o.expiration_date }}</td><td>{{ o.avg_price }}</td><td>{{ o.cost_basis }}</td>
+    <td>
+      <a href="/options/{{ o.option_ticker }}/edit">🖊</a>
+      <form method="post" action="/options/{{ o.option_ticker }}" style="display:inline">
+        <input type="hidden" name="delete" value="1">
+        <button type="submit">🗑️</button>
+      </form>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/src/financial_investing_platform/templates/risk.html
+++ b/src/financial_investing_platform/templates/risk.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Risk Profiles</h1>
+<a href="/risk/new">Add Risk</a>
+<table>
+  <tr>
+    <th>Ticker</th><th>Min Prob OTM</th><th>Max Prob OTM</th><th>Min RORC</th><th>Last Updated</th><th>Actions</th>
+  </tr>
+  {% for r in risk_profiles %}
+  <tr>
+    <td>{{ r.ticker }}</td><td>{{ r.min_prob_OTM }}</td><td>{{ r.max_prob_OTM }}</td><td>{{ r.min_rorc }}</td><td>{{ r.last_updated }}</td>
+    <td>
+      <a href="/risk/{{ r.ticker }}/edit">🖊</a>
+      <form method="post" action="/risk/{{ r.ticker }}" style="display:inline">
+        <input type="hidden" name="delete" value="1">
+        <button type="submit">🗑️</button>
+      </form>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/src/financial_investing_platform/templates/risk_form.html
+++ b/src/financial_investing_platform/templates/risk_form.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ form_title }}</h1>
+<form method="post" action="{{ action }}">
+  <label>Ticker: <input type="text" name="ticker" value="{{ risk.ticker|default('') }}" {% if risk %}readonly{% endif %}></label><br>
+  <label>Min Prob OTM: <input type="number" step="0.01" name="min_prob_OTM" value="{{ risk.min_prob_OTM|default('') }}"></label><br>
+  <label>Max Prob OTM: <input type="number" step="0.01" name="max_prob_OTM" value="{{ risk.max_prob_OTM|default('') }}"></label><br>
+  <label>Min RORC: <input type="number" step="0.01" name="min_rorc" value="{{ risk.min_rorc|default('') }}"></label><br>
+  <button type="submit">Submit</button>
+</form>
+{% endblock %}

--- a/src/financial_investing_platform/templates/stock_form.html
+++ b/src/financial_investing_platform/templates/stock_form.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ form_title }}</h1>
+<form method="post" action="{{ action }}">
+  <label>Ticker: <input type="text" name="ticker" value="{{ stock.ticker|default('') }}" {% if stock %}readonly{% endif %}></label><br>
+  <label>Shares: <input type="number" name="shares" value="{{ stock.shares|default('') }}"></label><br>
+  <label>Avg Price Paid: <input type="number" step="0.01" name="avg_price_paid" value="{{ stock.avg_price_paid|default('') }}"></label><br>
+  <label>Cost Basis: <input type="number" step="0.01" name="cost_basis" value="{{ stock.cost_basis|default('') }}"></label><br>
+  <label>Current Price: <input type="number" step="0.01" name="current_price" value="{{ stock.current_price|default('') }}"></label><br>
+  <button type="submit">Submit</button>
+</form>
+{% endblock %}

--- a/src/financial_investing_platform/templates/stocks.html
+++ b/src/financial_investing_platform/templates/stocks.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Stocks</h1>
+<a href="/stocks/new">Add Stock</a>
+<table>
+  <tr>
+    <th>Ticker</th><th>Shares</th><th>Avg Price Paid</th><th>Cost Basis</th><th>Current Price</th><th>Last Updated</th><th>Actions</th>
+  </tr>
+  {% for s in stocks %}
+  <tr>
+    <td>{{ s.ticker }}</td><td>{{ s.shares }}</td><td>{{ s.avg_price_paid }}</td><td>{{ s.cost_basis }}</td><td>{{ s.current_price }}</td><td>{{ s.last_updated }}</td>
+    <td>
+      <a href="/stocks/{{ s.ticker }}/edit">🖊</a>
+      <form method="post" action="/stocks/{{ s.ticker }}" style="display:inline">
+        <input type="hidden" name="delete" value="1">
+        <button type="submit">🗑️</button>
+      </form>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- set up FastAPI app with session login and CRUD-style routes
- create Jinja2 templates for login, stock, option and risk pages
- include websocket snippet on options page for live prices

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687414f84c548329a854b72a002e0ab9